### PR TITLE
Ad mt retired items

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,11 @@
       <h2 class="item_title"><%= @item.title %></h2>
       <p>Price: <span style="color: #a55538"><%= number_to_currency(@item.price) %></span></p>
       <p>Description: <%= @item.description %></p>
-      <%= button_to "Add to cart", cart_path(item_id: @item.id), class: "btn btn-success" %>
+      <% if @item.retired == false  %>
+        <%= button_to "Add to cart", cart_path(item_id: @item.id), class: "btn btn-success" %>
+      <% else %>
+        <p>Sorry, this item is retired.<p>
+      <% end %>
     </div>
   </div>
 

--- a/db/migrate/20161103202532_add_retired_to_items.rb
+++ b/db/migrate/20161103202532_add_retired_to_items.rb
@@ -1,0 +1,5 @@
+class AddRetiredToItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :items, :retired, :boolean, :default  => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161103174405) do
+ActiveRecord::Schema.define(version: 20161103202532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,8 +34,9 @@ ActiveRecord::Schema.define(version: 20161103174405) do
     t.text     "description"
     t.float    "price"
     t.string   "image"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.boolean  "retired",     default: false
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/spec/features/items/user_cannot_add_retired_item_to_cart_spec.rb
+++ b/spec/features/items/user_cannot_add_retired_item_to_cart_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe "a user visits an item show page of a retired item" do
+  scenario "a user cannot add retired item to cart" do
+    item = Item.create(title: "cat sweater", description: "fuzzy", price: 5.75, image: "cat.jpg", retired: true)
+
+    visit item_path(item)
+
+    expect(page).to_not have_link("Add to Cart")
+    expect(page).to have_content("Sorry, this item is retired")
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,29 +4,29 @@ RSpec.describe Item, type: :model do
   describe "validations" do
     context "invalid attributes" do
       it "is invalid without a title" do
-        item = Item.new(description: "fuzzy", price: 5.75, image: "cat.jpg")
+        item = Item.new(description: "fuzzy", price: 5.75, image: "cat.jpg", retired: false)
         expect(item).to be_invalid
       end
 
       it "is invalid without a description" do
-        item = Item.new(title: "cat", price: 5.75, image: "cat.jpg")
+        item = Item.new(title: "cat", price: 5.75, image: "cat.jpg", retired: false)
         expect(item).to be_invalid
       end
 
       it "is invalid without a price" do
-        item = Item.new(title: "cat", description: "fuzzy", image: "cat.jpg")
+        item = Item.new(title: "cat", description: "fuzzy", image: "cat.jpg", retired: false)
         expect(item).to be_invalid
       end
 
       it "is invalid without an image" do
-        item = Item.new(title: "cat", description: "fuzzy", price: 5.75)
+        item = Item.new(title: "cat", description: "fuzzy", price: 5.75, retired: false)
         expect(item).to be_invalid
       end
     end
 
     context "valid attributes" do
       it "is valid with all attributes" do
-        item = Item.new(title: "cat", description: "fuzzy", price: 5.75, image: "cat.jpg")
+        item = Item.new(title: "cat", description: "fuzzy", price: 5.75, image: "cat.jpg", retired: false)
         expect(item).to be_valid
       end
     end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe Order, type: :model do
       user = User.create(name: "Bob", email: "cats@cats.cats", password: "cats")
       status = Status.create(name: "Completed")
       order = Order.create(user_id: user.id, status_id: status.id)
-      order.items.create(title: "cat sweater", description: "lovely", price: 9.99, image: "cat.jpg")
-      order.items.create(title: "dog sweater", description: "charming", price: 34.43, image: "dog.jpg")
+      order.items.create(title: "cat sweater", description: "lovely", price: 9.99, image: "cat.jpg", retired: false)
+      order.items.create(title: "dog sweater", description: "charming", price: 34.43, image: "dog.jpg", retired: false)
+
       expect(order.order_total).to eq(44.42)
     end
   end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     sequence :image do |n|
       "img tag #{n}"
     end
+  
   end
 
   factory :category do


### PR DESCRIPTION
@AliSchlereth @epintozzi 
Added the retired boolean column, with a default set to zero. We didn't validate for it because the default setting was automatically putting retired as false on every item. We also changed one item to be retired and "add to cart" no longer shows up on this item's show page. Instead it says "Sorry, this item is retired." (Spec says just "item retired," but we wanted it a little more user-friendly. We can of course change that if you'd like!)

✅ if looks good!

